### PR TITLE
Update index.html

### DIFF
--- a/public_html/linux/index.html
+++ b/public_html/linux/index.html
@@ -35,7 +35,7 @@
                     <ul>
                         <li>
                         	<a class="btn btn-primary btn-lg"
-	                            href="http://goo.gl/3si7b6">
+	                            href="http://lazynewbpack.com/linux/04024/download/x64/04024r2-x64.zip">
 	                            <span class="fa fa-download fa-lg"></span>x64 LNP DF v0.40.24 R2 (~79 MB)</a></li>
                     </ul>
                 </div>
@@ -47,7 +47,7 @@
                     <h4>x64 PyLNP Interface</h4>
                     <ul>
                         <li><p><a class="btn btn-success"
-                            href="http://goo.gl/3si7b6">
+                            href="http://lazynewbpack.com/linux/04024/download/x64/04024r2-x64.zip">
                             <i class="fa fa-download fa-lg"></i>x64 LNP DF v0.40.24 R2 (~79 MB)</a></p>
 						</li>
                     </ul>
@@ -56,7 +56,7 @@
                     <h4>i686 PyLNP Interface</h4>
                     <ul>
                         <li><p><a class="btn btn-success"
-                            href="http://goo.gl/sviJrU">
+                            href="http://lazynewbpack.com/linux/04024/download/i686/04024r2-i686.zip">
                             <i class="fa fa-download fa-lg"></i>i686 LNP DF v0.40.24 R2 (~79 MB)</a></p>
                         </li>
                     </ul>


### PR DESCRIPTION
changing the links to just hard links to the files. 

changed the links to the goo.gl links because you get to break down [which websites are hotlinking](http://i.imgur.com/5ZaVGfV.png) to file downloads, as well as get browser/[OS information](http://i.imgur.com/YqlQY8g.png). That way I can link the Readme in the package/ website / forum / DFFD / reddit to all the same download link and still track it. 

But google blocked it, so I am switching the links to hard links to my files. I may try to get some google-analytic event links to have the same effect later. 
